### PR TITLE
Fix/status message parameter order

### DIFF
--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -53,7 +53,7 @@ else:
 
     st = datetime.datetime.now()
     for i, memory in enumerate(memories):
-        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i, memory["Date"], datetime.datetime.now() - st), end=" ")
+        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i, datetime.datetime.now() - st), memory["Date"], end=" ")
         try:
             link = requests.post(memory["Download Link"]).text
             print("Success")

--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -53,7 +53,7 @@ else:
 
     st = datetime.datetime.now()
     for i, memory in enumerate(memories):
-        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i, datetime.datetime.now() - st), memory["Date"], end=" ")
+        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i + 1, datetime.datetime.now() - st), memory["Date"], end=" ")
         try:
             link = requests.post(memory["Download Link"]).text
             print("Success")

--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -53,7 +53,7 @@ else:
 
     st = datetime.datetime.now()
     for i, memory in enumerate(memories):
-        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i + 1, datetime.datetime.now() - st), memory["Date"], end=" ")
+        print("{}: Time Elapsed: {}. Getting URL for date {}:".format(i + 1, datetime.datetime.now() - st, memory["Date"]), end=" ")
         try:
             link = requests.post(memory["Download Link"]).text
             print("Success")


### PR DESCRIPTION
Fixes output format from:
`1: Time Elapsed: 2022-06-24 18:56:16 UTC. Getting URL for date 0:00:00.412939: Success`

to:
`1: Time Elapsed: 0:00:00.412939. Getting URL for date 2022-06-24 18:56:16 UTC: Success`

Also when getting memory urls start index from 1 instead of 0.