### PR TITLE
Fix/download error

### DIFF
--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -7,6 +7,7 @@ import json
 import requests
 import datetime
 import os
+import shutil
 
 # Helper Functions
 
@@ -21,6 +22,13 @@ def get_ext(memory_media_type):
     if memory["Media Type"] == "PHOTO":
         ext = "jpg"
     return ext
+
+def download_file_from_url(url, filename):
+    with requests.get(url, stream=True) as r:
+        with open(filename, 'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+
+    return filename
 
 overwrite = False # Overwrites existing useful memory metadata file
 
@@ -77,7 +85,7 @@ for memory in memories:
 
     print("Downloading File {}:".format(filename), end=" ")
     try:
-        urllib.request.urlretrieve(memory["url"], filename)
+        download_file_from_url(memory["url"], filename)
         modtime = datetime.datetime.timestamp(memory_datetime)
         os.utime(filename, (modtime, modtime))
         print("Success")

--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -31,6 +31,7 @@ def download_file_from_url(url, filename):
     return filename
 
 overwrite = False # Overwrites existing useful memory metadata file
+st = datetime.datetime.now()
 
 # Import Memories Data
 

--- a/memories-downloader.py
+++ b/memories-downloader.py
@@ -19,7 +19,7 @@ def get_datetime(memory_date):
 
 def get_ext(memory_media_type):
     ext = "mp4"
-    if memory["Media Type"] == "PHOTO":
+    if memory["Media Type"] == "Image" or memory["Media Type"] == "PHOTO":
         ext = "jpg"
     return ext
 


### PR DESCRIPTION
Replaces `urllib.request.urlretrieve` method of downloading file. Was getting SSL certificate error [0]

Now streams contents of url using `requests.get` into a local file.

[0]
```
Downloading File memories/2022-01-01-20009.mp4: Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 1350, in do_open
    encode_chunked=req.has_header('Transfer-encoding'))
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1277, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1323, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1272, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1032, in _send_output
    self.send(msg)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 972, in send
    self.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1447, in connect
    server_hostname=server_hostname)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ssl.py", line 423, in wrap_socket
    session=session
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ssl.py", line 870, in _create
    self.do_handshake()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ssl.py", line 1139, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1091)
```